### PR TITLE
Feature/rest errors alert

### DIFF
--- a/Chuck-Norris-facts.xcodeproj/project.pbxproj
+++ b/Chuck-Norris-facts.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		9A6DBDBC238CA3E0006D7805 /* Chuck_Norris_factsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6DBDBB238CA3E0006D7805 /* Chuck_Norris_factsUITests.swift */; };
 		9A768C3E239BDDC8008F895A /* TypeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A768C3D239BDDC8008F895A /* TypeError.swift */; };
 		9A768C42239BE66A008F895A /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A768C41239BE66A008F895A /* Network.swift */; };
+		9A768C45239C08B6008F895A /* UIViewController+dismissKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A768C44239C08B6008F895A /* UIViewController+dismissKeyboard.swift */; };
 		9A806F8A23929CA900BD7B8F /* HomeScreenTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A806F8923929CA900BD7B8F /* HomeScreenTest.swift */; };
 		9A8DEDEA2393F0F1000EA61B /* UIViewForSnapShot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8DEDE92393F0F1000EA61B /* UIViewForSnapShot.swift */; };
 		9A8DEDEC2393FE2A000EA61B /* FactViewCellTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8DEDEB2393FE2A000EA61B /* FactViewCellTest.swift */; };
@@ -121,6 +122,7 @@
 		9A6DBDBD238CA3E0006D7805 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9A768C3D239BDDC8008F895A /* TypeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeError.swift; sourceTree = "<group>"; };
 		9A768C41239BE66A008F895A /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
+		9A768C44239C08B6008F895A /* UIViewController+dismissKeyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+dismissKeyboard.swift"; sourceTree = "<group>"; };
 		9A806F8923929CA900BD7B8F /* HomeScreenTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenTest.swift; sourceTree = "<group>"; };
 		9A8DEDE92393F0F1000EA61B /* UIViewForSnapShot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewForSnapShot.swift; sourceTree = "<group>"; };
 		9A8DEDEB2393FE2A000EA61B /* FactViewCellTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactViewCellTest.swift; sourceTree = "<group>"; };
@@ -291,8 +293,8 @@
 		9A6DBD98238CA3DE006D7805 /* Chuck-Norris-facts */ = {
 			isa = PBXGroup;
 			children = (
-				9A768C3C239BDDB4008F895A /* Enum */,
 				9A58430B23982B9900C318FF /* NetworkLayer */,
+				9A768C3C239BDDB4008F895A /* Enum */,
 				9AF9BE1A238D51F9002A4B9D /* Extension */,
 				9AF9BE13238D4DD3002A4B9D /* Protocol */,
 				9A5EE4EF239A7F26001AB998 /* Model */,
@@ -407,6 +409,7 @@
 				9AF9BE1B238D6251002A4B9D /* Uicolor+AppColor.swift */,
 				9AF9BE1D238D62D3002A4B9D /* UIColor+ExtensionInit.swift */,
 				9A549AD8238EF6A500F3CF8C /* UIView+DesignView.swift */,
+				9A768C44239C08B6008F895A /* UIViewController+dismissKeyboard.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -710,6 +713,7 @@
 				9A584315239834F800C318FF /* ParametersEncoding.swift in Sources */,
 				9A58431A2398449200C318FF /* URLRequest.swift in Sources */,
 				9AC43CF32395F1530099F575 /* SearchFactViewController.swift in Sources */,
+				9A768C45239C08B6008F895A /* UIViewController+dismissKeyboard.swift in Sources */,
 				9A58431E2398460B00C318FF /* NetworkError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Chuck-Norris-facts.xcodeproj/project.pbxproj
+++ b/Chuck-Norris-facts.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		2342559EC175B56E0225F6CB /* Pods_Chuck_Norris_facts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3522636E8D1F74887D00B587 /* Pods_Chuck_Norris_facts.framework */; };
 		9A4A4EB6239B10950063CBAF /* Facts.json in Resources */ = {isa = PBXBuildFile; fileRef = 9A4A4EB5239B10950063CBAF /* Facts.json */; };
 		9A4A4EB7239B10950063CBAF /* Facts.json in Resources */ = {isa = PBXBuildFile; fileRef = 9A4A4EB5239B10950063CBAF /* Facts.json */; };
+		9A4A4EBD239B2AE70063CBAF /* AlertsErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4A4EBC239B2AE70063CBAF /* AlertsErrors.swift */; };
 		9A4AC267239A9101003CCF55 /* NetworkLayerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4AC266239A9101003CCF55 /* NetworkLayerTest.swift */; };
 		9A529541238DB3950059EB62 /* FactTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A529540238DB3950059EB62 /* FactTableViewCell.swift */; };
 		9A549AD9238EF6A500F3CF8C /* UIView+DesignView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A549AD8238EF6A500F3CF8C /* UIView+DesignView.swift */; };
@@ -39,6 +40,8 @@
 		9A6DBDA6238CA3E0006D7805 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9A6DBDA4238CA3E0006D7805 /* LaunchScreen.storyboard */; };
 		9A6DBDB1238CA3E0006D7805 /* Chuck_Norris_factsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6DBDB0238CA3E0006D7805 /* Chuck_Norris_factsTests.swift */; };
 		9A6DBDBC238CA3E0006D7805 /* Chuck_Norris_factsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6DBDBB238CA3E0006D7805 /* Chuck_Norris_factsUITests.swift */; };
+		9A768C3E239BDDC8008F895A /* TypeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A768C3D239BDDC8008F895A /* TypeError.swift */; };
+		9A768C42239BE66A008F895A /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A768C41239BE66A008F895A /* Network.swift */; };
 		9A806F8A23929CA900BD7B8F /* HomeScreenTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A806F8923929CA900BD7B8F /* HomeScreenTest.swift */; };
 		9A8DEDEA2393F0F1000EA61B /* UIViewForSnapShot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8DEDE92393F0F1000EA61B /* UIViewForSnapShot.swift */; };
 		9A8DEDEC2393FE2A000EA61B /* FactViewCellTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8DEDEB2393FE2A000EA61B /* FactViewCellTest.swift */; };
@@ -81,6 +84,7 @@
 		595382D733E46B8CF38F70D2 /* Pods_Chuck_Norris_facts_Chuck_Norris_factsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Chuck_Norris_facts_Chuck_Norris_factsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F08FF614184FB0CBA20F323 /* Pods-Chuck-Norris-facts-Chuck-Norris-factsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Chuck-Norris-facts-Chuck-Norris-factsTests.release.xcconfig"; path = "Target Support Files/Pods-Chuck-Norris-facts-Chuck-Norris-factsTests/Pods-Chuck-Norris-facts-Chuck-Norris-factsTests.release.xcconfig"; sourceTree = "<group>"; };
 		9A4A4EB5239B10950063CBAF /* Facts.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Facts.json; sourceTree = "<group>"; };
+		9A4A4EBC239B2AE70063CBAF /* AlertsErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertsErrors.swift; sourceTree = "<group>"; };
 		9A4AC266239A9101003CCF55 /* NetworkLayerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkLayerTest.swift; sourceTree = "<group>"; };
 		9A529540238DB3950059EB62 /* FactTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactTableViewCell.swift; sourceTree = "<group>"; };
 		9A549AD8238EF6A500F3CF8C /* UIView+DesignView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+DesignView.swift"; sourceTree = "<group>"; };
@@ -115,6 +119,8 @@
 		9A6DBDB7238CA3E0006D7805 /* Chuck-Norris-factsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Chuck-Norris-factsUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A6DBDBB238CA3E0006D7805 /* Chuck_Norris_factsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chuck_Norris_factsUITests.swift; sourceTree = "<group>"; };
 		9A6DBDBD238CA3E0006D7805 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9A768C3D239BDDC8008F895A /* TypeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeError.swift; sourceTree = "<group>"; };
+		9A768C41239BE66A008F895A /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
 		9A806F8923929CA900BD7B8F /* HomeScreenTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenTest.swift; sourceTree = "<group>"; };
 		9A8DEDE92393F0F1000EA61B /* UIViewForSnapShot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewForSnapShot.swift; sourceTree = "<group>"; };
 		9A8DEDEB2393FE2A000EA61B /* FactViewCellTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactViewCellTest.swift; sourceTree = "<group>"; };
@@ -194,6 +200,7 @@
 				9A58430F239833A500C318FF /* Enuns */,
 				9A58430C2398335400C318FF /* Protocol */,
 				9A632B082399799300C777E2 /* NetworkService.swift */,
+				9A768C41239BE66A008F895A /* Network.swift */,
 			);
 			path = NetworkLayer;
 			sourceTree = "<group>";
@@ -254,6 +261,7 @@
 			children = (
 				9A5EE4F4239A7FC9001AB998 /* FactDTO.swift */,
 				9A5EE4F2239A7F7C001AB998 /* Fact.swift */,
+				9A4A4EBC239B2AE70063CBAF /* AlertsErrors.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -283,12 +291,13 @@
 		9A6DBD98238CA3DE006D7805 /* Chuck-Norris-facts */ = {
 			isa = PBXGroup;
 			children = (
+				9A768C3C239BDDB4008F895A /* Enum */,
 				9A58430B23982B9900C318FF /* NetworkLayer */,
 				9AF9BE1A238D51F9002A4B9D /* Extension */,
 				9AF9BE13238D4DD3002A4B9D /* Protocol */,
+				9A5EE4EF239A7F26001AB998 /* Model */,
 				9AF9BE11238D4C7D002A4B9D /* View */,
 				9AF9BE12238D4C84002A4B9D /* Controller */,
-				9A5EE4EF239A7F26001AB998 /* Model */,
 				9A6DBD99238CA3DE006D7805 /* AppDelegate.swift */,
 				9A6DBD9B238CA3DE006D7805 /* SceneDelegate.swift */,
 				9A6DBDA2238CA3E0006D7805 /* Assets.xcassets */,
@@ -326,6 +335,14 @@
 				9A5EE4DF239A79C1001AB998 /* Mock */,
 			);
 			path = NetWorkLayerTest;
+			sourceTree = "<group>";
+		};
+		9A768C3C239BDDB4008F895A /* Enum */ = {
+			isa = PBXGroup;
+			children = (
+				9A768C3D239BDDC8008F895A /* TypeError.swift */,
+			);
+			path = Enum;
 			sourceTree = "<group>";
 		};
 		9A8DEDED23941CC5000EA61B /* Enum */ = {
@@ -671,6 +688,7 @@
 				9AF9BE17238D4F5D002A4B9D /* Home.swift in Sources */,
 				9A58430E2398337000C318FF /* ServiceProtocol.swift in Sources */,
 				9A6DBD9C238CA3DE006D7805 /* SceneDelegate.swift in Sources */,
+				9A768C3E239BDDC8008F895A /* TypeError.swift in Sources */,
 				9A58431C239845E500C318FF /* NetworkResponse.swift in Sources */,
 				9A5843202398469A00C318FF /* ProviderProtocol.swift in Sources */,
 				9A529541238DB3950059EB62 /* FactTableViewCell.swift in Sources */,
@@ -684,7 +702,9 @@
 				9AF9BE19238D4FCF002A4B9D /* HomeViewController.swift in Sources */,
 				9A584311239833BA00C318FF /* HTTPMethod.swift in Sources */,
 				9AF9BE1E238D62D3002A4B9D /* UIColor+ExtensionInit.swift in Sources */,
+				9A768C42239BE66A008F895A /* Network.swift in Sources */,
 				9A632B0523996AFF00C777E2 /* URLSessionProtocol.swift in Sources */,
+				9A4A4EBD239B2AE70063CBAF /* AlertsErrors.swift in Sources */,
 				9A5843132398341100C318FF /* HTTPTask.swift in Sources */,
 				9A5EE4F3239A7F7C001AB998 /* Fact.swift in Sources */,
 				9A584315239834F800C318FF /* ParametersEncoding.swift in Sources */,

--- a/Chuck-Norris-facts/Controller/HomeViewController.swift
+++ b/Chuck-Norris-facts/Controller/HomeViewController.swift
@@ -14,7 +14,6 @@ class HomeViewController: UIViewController {
     private let customView: Home
     
     private let disposeBag = DisposeBag()
-    private let network: Network
     private var sessionProvider : ProviderProtocol
     private var seachText = ""
     private var alert: AlertsError?
@@ -30,7 +29,6 @@ class HomeViewController: UIViewController {
     init(sessionProvider: ProviderProtocol) {
         self.sessionProvider = sessionProvider
         self.customView = Home()
-        self.network = Network()
         super.init(nibName: nil, bundle: nil)
         self.alert = AlertsError(controller: self)
         
@@ -43,7 +41,6 @@ class HomeViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        checkNetwork()
         customView.factsTableView.delegate = self
         customView.factsTableView.dataSource = self
         customView.factsTableView.register(FactTableViewCell.self, forCellReuseIdentifier: cellId)
@@ -57,7 +54,6 @@ class HomeViewController: UIViewController {
     
     // MARK: - Navigation
     private func setupNavigation() {
-        
         title = "Chuck Norris Facts"
         let addBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "magnifyingglass"), style: .done, target: self, action: #selector(searchFact))
         navigationItem.rightBarButtonItem = addBarButtonItem
@@ -72,28 +68,18 @@ class HomeViewController: UIViewController {
         present(search, animated: true, completion: nil)
         search.textForSearch.subscribe(onNext: {[weak self] searchFact in
             self?.seachText = searchFact
-            if (self?.checkNetwork())! {
-                self!.getFact()
-            }
+            self!.getFact()
         }).disposed(by: disposeBag)
         
     }
-    func checkNetwork() -> Bool {
-        let connected = network.isconnected()
-        if !connected {
-            alert?.presentAlertError(error: .notNetWork)
-        }
-        return connected
-    }
+    
     private func getFact() {
         sessionProvider.request(type: FactDTO.self, service: NetworkService.getTextSearch(FactDTO.self, self.seachText)) { response  in
             switch response {
             case let .success(result):
                 self.facts = result.result
             case let .failure(error):
-                
-                self.alert?.presentAlertError(error: .textLessThan3)
-                
+                self.alert?.showAlertNetWorError(error: error)
             }
             
         }

--- a/Chuck-Norris-facts/Controller/SearchFactViewController.swift
+++ b/Chuck-Norris-facts/Controller/SearchFactViewController.swift
@@ -11,15 +11,20 @@ import RxSwift
 class SearchFactViewController: UIViewController {
     private let customView = SearchFact(frame: .zero)
     var textForSearch = PublishSubject<String>()
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    }
+    private let network = Network()
+    private var alert: AlertsError!
     
     // MARK: - Init
+    override func viewDidLoad() {
+        super.viewDidLoad()
+       
+        self.hideKeyboardWhenTappedAround()
+    }
+    
+    
+    
     override func loadView() {
         view = customView
-      
         setupInitial()
     }
     
@@ -39,9 +44,27 @@ class SearchFactViewController: UIViewController {
     
     @objc func searchFact(){
         guard let searchFact = customView.search.text else {return}
-        textForSearch.onNext(searchFact)
-        dismiss(animated: true, completion: nil)
+        if noMistake(text: searchFact) {
+            textForSearch.onNext(searchFact)
+            dismiss(animated: true, completion: nil)
+        }
+            
+        
     }
+    func noMistake(text: String) -> Bool {
+        alert = AlertsError(controller: self)
+        var notError = true
+        if !network.isconnected(){
+            alert?.showAlertError(error: .notNetWork)
+            notError = false
+        }
+        if text.count < 3{
+            alert?.showAlertError(error: .textLessThan3)
+            notError = false
+        }
+        return notError
+    }
+    
     
     // MARK: - Move view to insert keyboard
     @objc func keyboardWillShow(notification: NSNotification) {
@@ -58,6 +81,7 @@ class SearchFactViewController: UIViewController {
         }
     }
 }
+
 
 extension SearchFactViewController: UITextFieldDelegate{
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {

--- a/Chuck-Norris-facts/Enum/TypeError.swift
+++ b/Chuck-Norris-facts/Enum/TypeError.swift
@@ -1,0 +1,15 @@
+//
+//  TypeError.swift
+//  Chuck-Norris-facts
+//
+//  Created by Joao Batista on 07/12/19.
+//  Copyright © 2019 Joao Batista. All rights reserved.
+//
+
+import Foundation
+
+enum TypeError {
+    case notNetWork
+    case notConnectServe
+    case textLessThan3
+}

--- a/Chuck-Norris-facts/Enum/TypeError.swift
+++ b/Chuck-Norris-facts/Enum/TypeError.swift
@@ -11,5 +11,6 @@ import Foundation
 enum TypeError {
     case notNetWork
     case notConnectServe
+    case invalidSearch
     case textLessThan3
 }

--- a/Chuck-Norris-facts/Extension/UIViewController+dismissKeyboard.swift
+++ b/Chuck-Norris-facts/Extension/UIViewController+dismissKeyboard.swift
@@ -1,0 +1,22 @@
+//
+//  UIViewController+dismissKeyboard.swift
+//  Chuck-Norris-facts
+//
+//  Created by Joao Batista on 07/12/19.
+//  Copyright © 2019 Joao Batista. All rights reserved.
+//
+
+import Foundation
+import UIKit
+extension UIViewController{
+    func hideKeyboardWhenTappedAround() {
+        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+    
+    @objc func dismissKeyboard() {
+        view.endEditing(true)
+    }
+}
+

--- a/Chuck-Norris-facts/Model/AlertsErrors.swift
+++ b/Chuck-Norris-facts/Model/AlertsErrors.swift
@@ -13,52 +13,59 @@ class AlertsError {
     private var controller: UIViewController
     private var messageError = String()
     private var titleError = String()
+    
     init(controller: UIViewController) {
         self.controller = controller
     }
     
-    func presentAlertError(error: TypeError){
+    func showAlertError(error: TypeError){
         switch error {
         case .notConnectServe:
             titleError = "Unable to connect to server"
             messageError = "We were unable to perform your search at this time, please try again later."
             self.showAlert(title: titleError, message: messageError)
+            
         case .notNetWork:
             titleError = "Warning"
-            messageError = "The Internet is not available"
+            messageError = "The Internet is not available. Please check your connection and try again."
             let alertAction = UIAlertAction(title: "Dismiss", style: .default, handler: nil)
             self.showAlert(title: titleError, message: messageError, alertActions: [alertAction])
+            
         case .textLessThan3:
-           messageError = "Unable to connect to server"
-            titleError = "We were unable to perform your search at this time, please try again later."
+            titleError = "Small text"
+            messageError = "Search text length must be between 3 and 120 characters."
             self.showAlert(title: titleError, message: messageError)
-        }
-    }
-    
-    
-    private func showAlert(title: String, message: String,  alertActions: [UIAlertAction] = [UIAlertAction(title: "Ok", style: .default, handler: nil)]){
-        DispatchQueue.main.async {
-            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-            self.setAlertActions(alert: alert, alertAction: alertActions)
-            self.controller.present(alert, animated: true)
+            
+        case .invalidSearch:
+            titleError = "Invalid search"
+            messageError = "Could not perform a search with this term. Please try again with another word or phrase."
+            self.showAlert(title: titleError, message: messageError)
         }
         
     }
+    func showAlertNetWorError(error: NetworkError){
+        var typeError = TypeError.notConnectServe
+        switch error {
+        case .clientError(_,  _):
+            typeError =  TypeError.invalidSearch
+        default:
+            typeError = TypeError.notConnectServe
+        }
+        showAlertError(error: typeError)
+    }
     
+    private func showAlert(title: String, message: String,  alertActions: [UIAlertAction] = [UIAlertAction(title: "Ok", style: .default, handler: nil)]){
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        self.setAlertActions(alert: alertController, alertAction: alertActions)
+        DispatchQueue.main.async {
+            self.controller.present(alertController, animated: true)
+        }
+        
+    }
     
     private func setAlertActions(alert: UIAlertController, alertAction: [UIAlertAction]) {
         for actions in alertAction{
             alert.addAction(actions)
         }
     }
-
-
-//       func showAlert() {
-//           if !isInternetAvailable() {
-//               let alert = UIAlertController(title: "Warning", message: "The Internet is not available", preferredStyle: .alert)
-//               let action = UIAlertAction(title: "Dismiss", style: .default, handler: nil)
-//               alert.addAction(action)
-//               present(alert, animated: true, completion: nil)
-//           }
-//       }
 }

--- a/Chuck-Norris-facts/Model/AlertsErrors.swift
+++ b/Chuck-Norris-facts/Model/AlertsErrors.swift
@@ -1,0 +1,64 @@
+//
+//  AlertsErrors.swift
+//  Chuck-Norris-facts
+//
+//  Created by Joao Batista on 06/12/19.
+//  Copyright © 2019 Joao Batista. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class AlertsError {
+    private var controller: UIViewController
+    private var messageError = String()
+    private var titleError = String()
+    init(controller: UIViewController) {
+        self.controller = controller
+    }
+    
+    func presentAlertError(error: TypeError){
+        switch error {
+        case .notConnectServe:
+            titleError = "Unable to connect to server"
+            messageError = "We were unable to perform your search at this time, please try again later."
+            self.showAlert(title: titleError, message: messageError)
+        case .notNetWork:
+            titleError = "Warning"
+            messageError = "The Internet is not available"
+            let alertAction = UIAlertAction(title: "Dismiss", style: .default, handler: nil)
+            self.showAlert(title: titleError, message: messageError, alertActions: [alertAction])
+        case .textLessThan3:
+           messageError = "Unable to connect to server"
+            titleError = "We were unable to perform your search at this time, please try again later."
+            self.showAlert(title: titleError, message: messageError)
+        }
+    }
+    
+    
+    private func showAlert(title: String, message: String,  alertActions: [UIAlertAction] = [UIAlertAction(title: "Ok", style: .default, handler: nil)]){
+        DispatchQueue.main.async {
+            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+            self.setAlertActions(alert: alert, alertAction: alertActions)
+            self.controller.present(alert, animated: true)
+        }
+        
+    }
+    
+    
+    private func setAlertActions(alert: UIAlertController, alertAction: [UIAlertAction]) {
+        for actions in alertAction{
+            alert.addAction(actions)
+        }
+    }
+
+
+//       func showAlert() {
+//           if !isInternetAvailable() {
+//               let alert = UIAlertController(title: "Warning", message: "The Internet is not available", preferredStyle: .alert)
+//               let action = UIAlertAction(title: "Dismiss", style: .default, handler: nil)
+//               alert.addAction(action)
+//               present(alert, animated: true, completion: nil)
+//           }
+//       }
+}

--- a/Chuck-Norris-facts/NetworkLayer/Network.swift
+++ b/Chuck-Norris-facts/NetworkLayer/Network.swift
@@ -11,7 +11,6 @@ import Foundation
 import SystemConfiguration
 
 class Network {
-    
     func isconnected() -> Bool {
         var zeroAddress = sockaddr_in()
         zeroAddress.sin_len = UInt8(MemoryLayout.size(ofValue: zeroAddress))

--- a/Chuck-Norris-facts/NetworkLayer/Network.swift
+++ b/Chuck-Norris-facts/NetworkLayer/Network.swift
@@ -1,0 +1,35 @@
+//
+//  Network.swift
+//  Chuck-Norris-facts
+//
+//  Created by Joao Batista on 07/12/19.
+//  Copyright © 2019 Joao Batista. All rights reserved.
+//
+
+
+import Foundation
+import SystemConfiguration
+
+class Network {
+    
+    func isconnected() -> Bool {
+        var zeroAddress = sockaddr_in()
+        zeroAddress.sin_len = UInt8(MemoryLayout.size(ofValue: zeroAddress))
+        zeroAddress.sin_family = sa_family_t(AF_INET)
+        
+        let defaultRouteReachability = withUnsafePointer(to: &zeroAddress) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {zeroSockAddress in
+                SCNetworkReachabilityCreateWithAddress(nil, zeroSockAddress)
+            }
+        }
+        
+        var flags = SCNetworkReachabilityFlags()
+        if !SCNetworkReachabilityGetFlags(defaultRouteReachability!, &flags) {
+            return false
+        }
+        let isReachable = flags.contains(.reachable)
+        let needsConnection = flags.contains(.connectionRequired)
+        return (isReachable && !needsConnection)
+    }
+    
+}

--- a/Chuck-Norris-facts/View/SearchFact.swift
+++ b/Chuck-Norris-facts/View/SearchFact.swift
@@ -26,6 +26,7 @@ class SearchFact: UIView {
         let textField = UITextField()
         textField.placeholder = "Searching..."
         textField.translatesAutoresizingMaskIntoConstraints = false
+        textField.keyboardType = .asciiCapable
         return textField
     }()
     let buttonSearch : UIButton = {


### PR DESCRIPTION
Add Rest Error Alert

has been added to the AlertsError class which generates a notification according to the TypeError enum error, it can also send a NetworkError error and convert it to the TypeError and generate its notification. Notification and error checking has been added to SearchFactViewController before performing a database search to avoid consuming user internet